### PR TITLE
Support passing TTF fonts as byte slices

### DIFF
--- a/sticker.go
+++ b/sticker.go
@@ -45,8 +45,8 @@ var (
 	// ErrInvalidDimensions gets returned when the requested image has an invalid width or height
 	ErrInvalidDimensions = errors.New("values for width or height must be positive")
 
-	// ErrMissingFont gets returned when there's no font specified in the options
-	ErrMissingFont = errors.New("no font specified")
+	// ErrMissingFontOption gets returned when there's no font specified in the options
+	ErrMissingFontOption = errors.New("no font option specified")
 )
 
 // NewImageGenerator returns a new ImageGenerator
@@ -74,7 +74,7 @@ func NewImageGenerator(options Options) (*ImageGenerator, error) {
 			return nil, err
 		}
 	} else {
-		return nil, ErrMissingFont
+		return nil, ErrMissingFontOption
 	}
 
 	f, err := freetype.ParseFont(ttf)

--- a/sticker.go
+++ b/sticker.go
@@ -44,6 +44,9 @@ type Options struct {
 var (
 	// ErrInvalidDimensions gets returned when the requested image has an invalid width or height
 	ErrInvalidDimensions = errors.New("values for width or height must be positive")
+
+	// ErrMissingFont gets returned when there's no font specified in the options
+	ErrMissingFont = errors.New("no font specified")
 )
 
 // NewImageGenerator returns a new ImageGenerator
@@ -71,7 +74,7 @@ func NewImageGenerator(options Options) (*ImageGenerator, error) {
 			return nil, err
 		}
 	} else {
-		return nil, errors.New("No font specified")
+		return nil, ErrMissingFont
 	}
 
 	f, err := freetype.ParseFont(ttf)

--- a/sticker.go
+++ b/sticker.go
@@ -34,6 +34,7 @@ type ImageGenerator struct {
 // Options contains all the settings for an ImageGenerator
 type Options struct {
 	TTFPath         string
+	TTF             []byte
 	Foreground      color.RGBA
 	Background      color.RGBA
 	BackgroundImage image.Image
@@ -57,10 +58,22 @@ func NewImageGenerator(options Options) (*ImageGenerator, error) {
 		options.MarginRatio = 0.2
 	}
 
-	ttf, err := ioutil.ReadFile(options.TTFPath)
-	if err != nil {
-		return nil, err
+	var ttf []byte
+
+	if len(options.TTF) > 0 {
+		ttf = options.TTF
+	} else if options.TTFPath != "" {
+		var err error
+
+		ttf, err = ioutil.ReadFile(options.TTFPath)
+
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		return nil, errors.New("No font specified")
 	}
+
 	f, err := freetype.ParseFont(ttf)
 	if err != nil {
 		return nil, err

--- a/sticker_test.go
+++ b/sticker_test.go
@@ -96,7 +96,7 @@ func TestImageGeneratorErrors(t *testing.T) {
 
 	_, err = NewImageGenerator(Options{})
 
-	if err != ErrMissingFont {
+	if err != ErrMissingFontOption {
 		t.Error("missing font error expected")
 	}
 }

--- a/sticker_test.go
+++ b/sticker_test.go
@@ -14,16 +14,17 @@ import (
 	"testing"
 
 	_ "image/png"
+
+	"golang.org/x/image/font/gofont/gobold"
 )
 
 const (
-	ttf  = "/usr/share/fonts/truetype/roboto/Roboto-Bold.ttf"
 	text = "Lorem ipsum!"
 )
 
 func TestPlaceholder(t *testing.T) {
 	gen, err := NewImageGenerator(Options{
-		TTFPath:     ttf,
+		TTF:         gobold.TTF,
 		MarginRatio: 0.2,
 		Foreground:  color.RGBA{0x96, 0x96, 0x96, 0xff},
 		Background:  color.RGBA{0xcc, 0xcc, 0xcc, 0xff},
@@ -77,7 +78,7 @@ func TestPlaceholder(t *testing.T) {
 
 func TestErrors(t *testing.T) {
 	gen, _ := NewImageGenerator(Options{
-		TTFPath: ttf,
+		TTF: gobold.TTF,
 	})
 
 	e := "Expected an error for invalid image dimensions, but received"
@@ -97,7 +98,7 @@ func TestErrors(t *testing.T) {
 
 func BenchmarkPlaceholder(b *testing.B) {
 	gen, _ := NewImageGenerator(Options{
-		TTFPath: ttf,
+		TTF: gobold.TTF,
 	})
 
 	for n := 0; n < b.N; n++ {

--- a/sticker_test.go
+++ b/sticker_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 const (
+	ttf  = "/usr/share/fonts/truetype/roboto/Roboto-Bold.ttf"
 	text = "Lorem ipsum!"
 )
 
@@ -73,6 +74,30 @@ func TestPlaceholder(t *testing.T) {
 		// Roboto could have been updated or a newer freetype behaves different
 		// We account for this by allowing 1% of pixels to differ between the two images
 		t.Errorf("Expected generated image to match example/lorem.png, but it doesn't: %d pixel mismatches", errs)
+	}
+}
+
+func TestImageGeneratorErrors(t *testing.T) {
+	_, err := NewImageGenerator(Options{
+		TTF: gobold.TTF,
+	})
+
+	if err != nil {
+		t.Error("no error expected")
+	}
+
+	_, err = NewImageGenerator(Options{
+		TTFPath: ttf,
+	})
+
+	if err != nil && !os.IsNotExist(err) {
+		t.Error("no error expected")
+	}
+
+	_, err = NewImageGenerator(Options{})
+
+	if err != ErrMissingFont {
+		t.Error("missing font error expected")
 	}
 }
 


### PR DESCRIPTION
I wanted to use a font from https://godoc.org/golang.org/x/image instead of reading a file so I added a way to pass a byte slice instead of a file path and depending on what's filled, use the appropriate value.